### PR TITLE
Add brightness adjustment and auto brightness on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Text display features:
 - Configurable font sizes
 - Page-based text display
 - Screen status tracking
+- Brightness level adjustment
+- Auto brightness on/off
 
 Image display capabilities: (TODO)
 - 1-bit, 576x136 pixel BMP format

--- a/services/device.py
+++ b/services/device.py
@@ -50,6 +50,29 @@ class DeviceManager:
             self.logger.error(f"Error setting silent mode: {e}")
             return False
 
+    async def set_brightness(self, level: int, auto: bool = False) -> bool:
+        """Set the brightness level (0-41) for both glasses. If auto is True, enable auto brightness."""
+        try:
+            if not 0 <= level <= 41:
+                self.logger.error(f"Brightness level {level} out of range (0-41)")
+                return False
+            auto_byte = 0x01 if auto else 0x00
+            command = bytes([COMMANDS.BRIGHTNESS, level, auto_byte])
+            success = True
+            for client in [self.connector.left_client, self.connector.right_client]:
+                if client and client.is_connected:
+                    await self.connector.command_manager.send_command(
+                        client,
+                        command,
+                        expect_response=False
+                    )
+            mode = 'AUTO' if auto else 'MANUAL'
+            self.logger.info(f"Brightness set to {level} ({mode})")
+            return success
+        except Exception as e:
+            self.logger.error(f"Error setting brightness: {e}")
+            return False
+
     @property
     def battery_level(self) -> dict:
         """Get current battery levels"""

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -103,6 +103,7 @@ class COMMANDS:
     SILENT_MODE_OFF = 0x05 # 3 taps
     AI_ENABLE = 0x17 #long press left
     HEARTBEAT_CMD = bytes([0x25, 0x06, 0x00, 0x01, 0x04, 0x01])
+    BRIGHTNESS = 0x01
 
 class StateDisplay:
     """Display information derived from StateEvent definitions"""


### PR DESCRIPTION
This adds brightness adjustment to the SDK. The raw brightness value is an integer 0-41. The same call can also enable or disable auto brightness.

Example usage:
```
await glasses.device_manager.set_brightness(5, auto=False) # Dims the display and disables auto brightness
await glasses.device_manager.set_brightness(41, auto=True) # Sets the display to maximum brightness and enables auto brightness
```